### PR TITLE
new: constructor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ pip install git+https://github.com/ArangoDB-Community/ArangoRDF
 ##  Quickstart
 
 ```py
+from arango import ArangoClient
 from arango_rdf import ArangoRDF
 
+db = ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="")
+
+adb_rdf = ArangoRDF(db, graph="rdf_music")
+
 # RDF Import
-adb_rdf = ArangoRDF(host="http://localhost:8529", username="root", password="openSesame", database="rdf", graph="rdf_music")
 adb_rdf.init_rdf_collections(bnode="Blank")
 adb_rdf.import_rdf("./examples/data/music_schema.ttl", format="ttl")
 adb_rdf.import_rdf("./examples/data/beatles.ttl", format="ttl")
@@ -56,7 +60,7 @@ adb_rdf.export(f"./examples/data/rdfExport.ttl", format="ttl")
 adb_rdf.import_rdf(f"./examples/data/rdfExport.ttl", format="ttl")
 
 # Ontology Import
-adb_rdf_2 = ArangoRDF("http://localhost:8529", "root", "openSesame", "ontologyImport", "ontology_iao")
+adb_rdf_2 = ArangoRDF(db, graph="ontology_iao")
 adb_rdf_2.init_ontology_collections()
 adb_rdf_2.import_ontology("./examples/data/iao.owl")
 ```

--- a/arango_rdf/main.py
+++ b/arango_rdf/main.py
@@ -12,42 +12,22 @@ from typing import List, Union
 from arango import ArangoClient
 from arango.collection import EdgeCollection, StandardCollection
 from arango.cursor import Cursor
+from arango.database import StandardDatabase
 from rdflib import BNode, Graph, Literal, URIRef
 
 
 class ArangoRDF:
-    def __init__(
-        self, host: str, username: str, password: str, database: str, graph: str
-    ) -> None:
+    def __init__(self, db: StandardDatabase, graph: str) -> None:
         """
         Parameters
         ----------
-        host: str
-            Host url
-        username: str
-            Username for basic authentication
-        password: str
-            Password for basic authentication
-        database: str
-            Database name
+        db: StandardDatabase
+            The python-arango database client
         graph: str
             Graph name
         """
 
-        self.connection = ArangoClient(hosts=host)
-        sys_db = self.connection.db(
-            "_system", username=username, password=password, verify=False
-        )
-
-        if sys_db.has_database(database):
-            self.db = self.connection.db(
-                database, username=username, password=password, verify=False
-            )
-        else:
-            sys_db.create_database(database)
-            self.db = self.connection.db(
-                database, username=username, password=password, verify=False
-            )
+        self.db = db
 
         # Create the graph
         if self.db.has_graph(graph):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,26 +1,22 @@
+from arango import ArangoClient
 from arango_rdf import ArangoRDF
-from tests import PROJECT_DIR
 
-# rdf import
-kg = ArangoRDF(
-    "http://localhost:8529",
-    username="root",
-    password="",
-    database="rdf",
-    graph="rdf_music",
-)
-kg.init_rdf_collections(bnode="Blank")
-kg.import_rdf(f"{PROJECT_DIR}/examples/data/music_schema.ttl", format="ttl")
-kg.import_rdf(f"{PROJECT_DIR}/examples/data/beatles.ttl", format="ttl")
-kg.import_rdf(f"{PROJECT_DIR}/examples/data/iao.owl")
+db = ArangoClient(hosts="http://localhost:8529").db("_system", username="root", password="")
 
-# ontology import
-kg2 = ArangoRDF("http://localhost:8529", "root", "", "ontologyImport", "ontology_iao")
-kg2.init_ontology_collections()
-kg2.import_ontology(f"{PROJECT_DIR}/examples/data/iao.owl")
+adb_rdf = ArangoRDF(db, graph="rdf_music")
 
-# export to file
-kg.export(f"{PROJECT_DIR}/examples/data/rdfExport.ttl", format="ttl")
+# RDF Import
+adb_rdf.init_rdf_collections(bnode="Blank")
+adb_rdf.import_rdf("./examples/data/music_schema.ttl", format="ttl")
+adb_rdf.import_rdf("./examples/data/beatles.ttl", format="ttl")
 
-# Re-import Export
-kg.import_rdf(f"{PROJECT_DIR}/examples/data/rdfExport.ttl", format="ttl")
+# RDF Export
+adb_rdf.export(f"./examples/data/rdfExport.ttl", format="ttl")
+
+# Re-import RDF Export
+adb_rdf.import_rdf(f"./examples/data/rdfExport.ttl", format="ttl")
+
+# Ontology Import
+adb_rdf_2 = ArangoRDF(db, graph="ontology_iao")
+adb_rdf_2.init_ontology_collections()
+adb_rdf_2.import_ontology("./examples/data/iao.owl")


### PR DESCRIPTION
Replaces existing `ArangoRDF` constructor parameters in favour of a `python-arango` database client (`StandardDatabase`), similar to how the adapter constructors work.


We still need to discuss the other `ArangoRDF` constructor parameter, `graph`. We may want to instead move this to the `import_rdf` and `import_ontology` APIs...