### PR TITLE
new: `ArangoRDFImportException`

### DIFF
--- a/arango_rdf/exception.py
+++ b/arango_rdf/exception.py
@@ -10,14 +10,19 @@ class ArangoRDFException(Exception):
 class ArangoRDFImportException(ArangoRDFException):
     """Exception for import errors."""
 
-    def __init__(self, error: str, documents: Jsons) -> None:
+    def __init__(self, error: str, collection: str, documents: Jsons) -> None:
         """Initialize import exception.
 
         :param error: The error message from the failed import
         :type error: str
+        :param collection: The collection that failed to import
+        :type collection: str
         :param documents: The batch of documents that failed to import
         :type documents: list
         """
         self.error = error
+        self.collection = collection
         self.documents = documents
-        super().__init__(f"Import error: {error}. Failed documents: {documents}")
+        super().__init__(
+            f"Import error in {collection}: {error}. Failed documents: {documents}"
+        )

--- a/arango_rdf/exception.py
+++ b/arango_rdf/exception.py
@@ -1,0 +1,23 @@
+from .typings import Jsons
+
+
+class ArangoRDFException(Exception):
+    """Base exception for ArangoRDF."""
+
+    pass
+
+
+class ArangoRDFImportException(ArangoRDFException):
+    """Exception for import errors."""
+
+    def __init__(self, error: str, documents: Jsons) -> None:
+        """Initialize import exception.
+
+        :param error: The error message from the failed import
+        :type error: str
+        :param documents: The batch of documents that failed to import
+        :type documents: list
+        """
+        self.error = error
+        self.documents = documents
+        super().__init__(f"Import error: {error}. Failed documents: {documents}")

--- a/arango_rdf/main.py
+++ b/arango_rdf/main.py
@@ -3350,7 +3350,7 @@ class ArangoRDF(AbstractArangoRDF):
                 e_str = str(e)
 
                 logger.error(f"Error inserting documents: {e_str}")
-                raise ArangoRDFImportException(e_str, list(doc_list))
+                raise ArangoRDFImportException(e_str, col, list(doc_list))
 
             logger.debug(f"Insert Result: {result}")
 

--- a/arango_rdf/main.py
+++ b/arango_rdf/main.py
@@ -26,6 +26,7 @@ from rich.progress import Progress
 
 from .abc import AbstractArangoRDF
 from .controller import ArangoRDFController
+from .exception import ArangoRDFImportException
 from .typings import (
     ADBDocs,
     ADBMetagraph,
@@ -3339,9 +3340,19 @@ class ArangoRDF(AbstractArangoRDF):
                 is_edge = col in self.__e_col_map
                 self.db.create_collection(col, edge=is_edge)
 
-            result = self.db.collection(col).insert_many(doc_list, **adb_import_kwargs)
+            logger.debug(f"Inserting Documents: {doc_list}")
 
-            logger.debug(result)
+            try:
+                result = self.db.collection(col).insert_many(
+                    doc_list, **adb_import_kwargs
+                )
+            except Exception as e:
+                e_str = str(e)
+
+                logger.error(f"Error inserting documents: {e_str}")
+                raise ArangoRDFImportException(e_str, list(doc_list))
+
+            logger.debug(f"Insert Result: {result}")
 
             del self.__adb_docs[col]
 

--- a/arango_rdf/typings.py
+++ b/arango_rdf/typings.py
@@ -10,11 +10,12 @@ __all__ = [
     "TypeMap",
 ]
 
-from typing import Any, DefaultDict, Dict, Set, Tuple, Union
+from typing import Any, DefaultDict, Dict, List, Set, Tuple, Union
 
 from rdflib import BNode, Literal, URIRef
 
 Json = Dict[str, Any]
+Jsons = List[Json]
 ADBMetagraph = Dict[str, Dict[str, Set[str]]]
 
 # ADBDocsRPT = DefaultDict[str, List[Json]]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5352,4 +5352,3 @@ def test_pgt_import_exception_from_schema_violation() -> None:
     adbrdf.rdf_to_arangodb_by_pgt("Test", g)
 
     db.delete_graph("Test", drop_collections=True)
-    db.delete_collection("Person")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5334,6 +5334,7 @@ def test_pgt_import_exception_from_schema_violation() -> None:
         adbrdf.rdf_to_arangodb_by_pgt("Test", g)
 
     assert "Invalid Person document" in str(e.value.error)
+    assert "Person" == e.value.collection
     assert len(e.value.documents) == 1
 
     g = RDFGraph()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5350,3 +5350,6 @@ def test_pgt_import_exception_from_schema_violation() -> None:
     )
 
     adbrdf.rdf_to_arangodb_by_pgt("Test", g)
+
+    db.delete_graph("Test", drop_collections=True)
+    db.delete_collection("Person")


### PR DESCRIPTION
Introduces `ArangoRDFImportException` as a custom Exception class that is raised if the `insert_many` operation raises a python-arango exception.

Useful to know which batch of insert failed, along with the original Exception message