### PR TITLE
new: `resource_collection_name`, `migrate_edges_to_attributes()`, `uri_map_collection_name`

### DIFF
--- a/arango_rdf/main.py
+++ b/arango_rdf/main.py
@@ -1250,6 +1250,7 @@ class ArangoRDF(AbstractArangoRDF):
         graph_name: str,
         edge_collection_name: str,
         attribute_name: Optional[str] = None,
+        edge_direction: str = "OUTBOUND",
     ) -> int:
         """RDF --> ArangoDB (PGT): Migrate all edges in the specified edge collection to
         attributes. This method is useful when combined with the
@@ -1267,12 +1268,18 @@ class ArangoRDF(AbstractArangoRDF):
         :param attribute_name: The name of the attribute to migrate the edges to.
             Defaults to **edge_collection_name**, prefixed with an underscore (_).
         :type attribute_name: Optional[str]
+        :param edge_direction: The direction of the edges to migrate.
+            Defaults to **OUTBOUND**.
+        :type edge_direction: str
         :return: The number of documents updated.
         :rtype: int
         """
 
         if not self.db.has_graph(graph_name):
             raise ValueError(f"Graph '{graph_name}' does not exist")
+
+        if edge_direction.upper() not in {"OUTBOUND", "INBOUND", "ANY"}:
+            raise ValueError(f"Invalid edge direction: {edge_direction}")
 
         graph = self.db.graph(graph_name)
 
@@ -1294,7 +1301,7 @@ class ArangoRDF(AbstractArangoRDF):
             query = f"""
                 FOR doc IN @@v_col
                     LET labels = (
-                        FOR v IN 1 OUTBOUND doc @@e_col
+                        FOR v IN 1 {edge_direction} doc @@e_col
                             RETURN v._label
                     )
 

--- a/arango_rdf/main.py
+++ b/arango_rdf/main.py
@@ -1291,9 +1291,6 @@ class ArangoRDF(AbstractArangoRDF):
         if edge_direction.upper() not in {"OUTBOUND", "INBOUND", "ANY"}:
             raise ValueError(f"Invalid edge direction: {edge_direction}")
 
-        if sort_clause is None:
-            sort_clause = ""
-
         if not return_clause:
             raise ValueError("**return_clause** cannot be empty")
 
@@ -1322,7 +1319,7 @@ class ArangoRDF(AbstractArangoRDF):
                 FOR doc IN @@v_col
                     LET labels = (
                         FOR v IN 1 {edge_direction} doc @@e_col
-                            SORT {sort_clause}
+                            {f"SORT {sort_clause}" if sort_clause else ""}
                             RETURN {return_clause}
                     )
 

--- a/arango_rdf/main.py
+++ b/arango_rdf/main.py
@@ -732,7 +732,8 @@ class ArangoRDF(AbstractArangoRDF):
         overwrite_graph: bool = False,
         batch_size: Optional[int] = None,
         namespace_collection_name: Optional[str] = None,
-        iri_collection_name: Optional[str] = None,
+        uri_map_collection_name: Optional[str] = None,
+        resource_collection_name: Optional[str] = None,
         **adb_import_kwargs: Any,
     ) -> ADBGraph:
         """Create an ArangoDB Graph from an RDF Graph using
@@ -806,15 +807,22 @@ class ArangoRDF(AbstractArangoRDF):
             which means that the namespace prefixes will not be stored.
             Not included in the ArangoDB Graph Edge Definitions.
         :type namespace_collection_name: str | None
-        :param iri_collection_name: If specified, in addition to storing the IRIs of
-            **rdf_graph** in their respective collection, the IRIs will also be stored in
+        :param uri_map_collection_name: If specified, in addition to storing the URIs of
+            **rdf_graph** in their respective collection, the URIs will also be stored in
             the specified ArangoDB Collection to map to the collection name they correspond to.
             This could be then used for multi-file imports, allowing ArangoRDF to
-            check if the IRIs of **rdf_graph** have already been imported into the
+            check if the URIs of **rdf_graph** have already been imported into the
             ArangoDB Graph to avoid going through the ArangoDB Collection Mapping
-            Process (for that IRI) again. Not included in the ArangoDB Graph
-            Edge Definitions.
-        :type iri_collection_name: str | None
+            Process (for that URI) again. Not included in the ArangoDB Graph
+            Edge Definitions. Cannot be used in conjunction with **resource_collection_name**.
+        :type uri_map_collection_name: str | None
+        :param resource_collection_name: If specified, will use this name as the
+            ArangoDB Collection to store **all** RDF Resources, except Class and Property.
+            This is useful for cases where you want to combine both RPT and PGT behavior, where
+            rdf:type statements are stored as both edges and optionally as a property (i.e _types list),
+            but not used for the ArangoDB Collection Mapping Process. Defaults to None.
+            Cannot be used in conjunction with **uri_map_collection_name**.
+        :type resource_collection_name: str | None
         :param adb_import_kwargs: Keyword arguments to specify additional
             parameters for the ArangoDB Data Ingestion process.
             The full parameter list is
@@ -839,12 +847,23 @@ class ArangoRDF(AbstractArangoRDF):
 
         self.__rdf_graph = rdf_graph
         self.__adb_key_statements = self.extract_adb_key_statements(rdf_graph)
-        self.__iri_collection: Optional[StandardCollection] = None
-        if iri_collection_name:
-            if not self.__db.has_collection(iri_collection_name):
-                self.__db.create_collection(iri_collection_name)
+        self.__uri_map_collection: Optional[StandardCollection] = None
+        if uri_map_collection_name:
+            if resource_collection_name:
+                m = "Cannot specify both **uri_map_collection_name** and **resource_collection_name**."  # noqa: E501
+                raise ValueError(m)
 
-            self.__iri_collection = self.__db.collection(iri_collection_name)
+            if not self.__db.has_collection(uri_map_collection_name):
+                self.__db.create_collection(uri_map_collection_name)
+
+            self.__uri_map_collection = self.__db.collection(uri_map_collection_name)
+
+        self.__resource_collection: Optional[StandardCollection] = None
+        if resource_collection_name:
+            if not self.__db.has_collection(resource_collection_name):
+                self.__db.create_collection(resource_collection_name)
+
+            self.__resource_collection = self.__db.collection(resource_collection_name)
 
         # Reset the ArangoDB Config
         self.__adb_docs = defaultdict(lambda: defaultdict(dict))
@@ -887,11 +906,8 @@ class ArangoRDF(AbstractArangoRDF):
 
         rdf_graph_has_adb_col_statements = (None, self.adb_col_uri, None) in rdf_graph
         if adb_col_statements and rdf_graph_has_adb_col_statements:
-            m = """
-                Ambiguity Error: Cannot specify both **adb_col_statements**
-                and **rdf_graph** with ArangoDB Collection statements.
-            """
-            raise Exception(m)
+            m = "Cannot specify both **adb_col_statements** and **rdf_graph** with ArangoDB Collection statements."  # noqa: E501
+            raise ValueError(m)
 
         elif adb_col_statements:
             self.__adb_col_statements = adb_col_statements
@@ -912,7 +928,7 @@ class ArangoRDF(AbstractArangoRDF):
             # us to run the ArangoDB Collection Mapping algorithm
             # regardless of **write_adb_col_statements**
             self.__adb_col_statements = self.write_adb_col_statements(
-                self.__rdf_graph, self.__adb_col_statements, iri_collection_name
+                self.__rdf_graph, self.__adb_col_statements, uri_map_collection_name
             )
 
         ###########################
@@ -1017,7 +1033,7 @@ class ArangoRDF(AbstractArangoRDF):
         self,
         rdf_graph: RDFGraph,
         adb_col_statements: Optional[RDFGraph] = None,
-        iri_collection_name: Optional[str] = None,
+        uri_map_collection_name: Optional[str] = None,
     ) -> RDFGraph:
         """RDF -> ArangoDB (PGT): Run the ArangoDB Collection Mapping Process for
         **rdf_graph** to map RDF Resources to their respective ArangoDB Collection.
@@ -1058,13 +1074,13 @@ class ArangoRDF(AbstractArangoRDF):
         with get_spinner_progress("(RDF → ADB): Write Col Statements") as rp:
             rp.add_task("")
 
-            # 0. Add IRI Collection statements
-            if iri_collection_name:
-                if not self.__db.has_collection(iri_collection_name):
-                    m = f"Iri collection '{iri_collection_name}' does not exist"
+            # 0. Add URI Collection statements
+            if uri_map_collection_name:
+                if not self.__db.has_collection(uri_map_collection_name):
+                    m = f"URI collection '{uri_map_collection_name}' does not exist"
                     raise ValueError(m)
 
-                for doc in self.__db.collection(iri_collection_name):
+                for doc in self.__db.collection(uri_map_collection_name):
                     uri = URIRef(doc["_uri"])
                     collection = str(doc["collection"])
                     self.__add_adb_col_statement(uri, collection, True)
@@ -1108,18 +1124,18 @@ class ArangoRDF(AbstractArangoRDF):
         return self.__adb_col_statements
 
     def migrate_unknown_resources(
-        self, graph_name: str, iri_collection_name: str, **kwargs: Any
+        self, graph_name: str, uri_map_collection_name: str, **kwargs: Any
     ) -> Tuple[int, int]:
-        """RDF -> ArangoDB: Migrate all UnknownResource statements to their
+        """RDF -> ArangoDB (PGT): Migrate all UnknownResource statements to their
         respective ArangoDB Collection.
 
         NOTE: This method is only available if the user has passed a
-        value to the **iri_collection** parameter of the
+        value to the **uri_map_collection_name** parameter of the
         :func:`rdf_to_arangodb_by_pgt` method.
 
         This method will migrate all UnknownResource statements to their
         respective ArangoDB Collection based on if the same RDF Resource
-        exists in the **iri_collection**.
+        exists in the **uri_map_collection_name**.
 
         Recommended to run this method after :func:`rdf_to_arangodb_by_pgt`
         if the user is not interested in maintaining the UnknownResource
@@ -1127,9 +1143,9 @@ class ArangoRDF(AbstractArangoRDF):
 
         :param graph_name: The name of the graph to migrate the Unknown Resources from.
         :type graph_name: str
-        :param iri_collection_name: The name of the IRI collection to migrate
+        :param uri_map_collection_name: The name of the URI collection to migrate
             the Unknown Resources to.
-        :type iri_collection_name: str
+        :type uri_map_collection_name: str
         :param kwargs: Keyword arguments passed to the AQL Query execution.
         :type kwargs: Any
 
@@ -1140,14 +1156,14 @@ class ArangoRDF(AbstractArangoRDF):
         ur_collection_name = f"{graph_name}_UnknownResource"
 
         ur_collection = self.__db.collection(ur_collection_name)
-        iri_collection = self.__db.collection(iri_collection_name)
+        uri_map_collection = self.__db.collection(uri_map_collection_name)
 
         if ur_collection.count() == 0:
             logger.info("No Unknown Resources to migrate")
             return 0, 0
 
-        if iri_collection.count() == 0:
-            logger.info("No IRI Collection to migrate to")
+        if uri_map_collection.count() == 0:
+            logger.info("No URI Collection to migrate to")
             return 0, 0
 
         old_ur_count = ur_collection.count()
@@ -1155,10 +1171,10 @@ class ArangoRDF(AbstractArangoRDF):
         query = """
            FOR doc IN @@UR
             LET collection = FIRST(
-                FOR iri IN @@IRI
-                    FILTER doc._key == iri._key
+                FOR uri IN @@URI
+                    FILTER doc._key == uri._key
                     LIMIT 1
-                    RETURN iri.collection
+                    RETURN uri.collection
             )
             FILTER collection
 
@@ -1181,7 +1197,7 @@ class ArangoRDF(AbstractArangoRDF):
 
         bind_vars = {
             "@UR": ur_collection_name,
-            "@IRI": iri_collection_name,
+            "@URI": uri_map_collection_name,
             "graph": graph_name,
         }
 
@@ -1228,6 +1244,73 @@ class ArangoRDF(AbstractArangoRDF):
         logger.info(m)
 
         return ur_count_diff, edge_count
+
+    def migrate_edges_to_attributes(
+        self,
+        graph_name: str,
+        edge_collection_name: str,
+        attribute_name: Optional[str] = None,
+    ) -> int:
+        """RDF --> ArangoDB (PGT): Migrate all edges in the specified edge collection to
+        attributes. This method is useful when combined with the
+        **resource_collection_name** parameter of the :func:`rdf_to_arangodb_by_pgt`
+        method.
+
+        NOTE: It is recommended to run this method with **edge_collection_name** set
+        to **"type"** after :func:`rdf_to_arangodb_by_pgt` if the user has set the
+        **resource_collection_name** parameter.
+
+        :param graph_name: The name of the graph to migrate the edges from.
+        :type graph_name: str
+        :param edge_collection_name: The name of the edge collection to migrate.
+        :type edge_collection_name: str
+        :param attribute_name: The name of the attribute to migrate the edges to.
+            Defaults to **edge_collection_name**, prefixed with an underscore (_).
+        :type attribute_name: Optional[str]
+        :return: The number of documents updated.
+        :rtype: int
+        """
+
+        if not self.db.has_graph(graph_name):
+            raise ValueError(f"Graph '{graph_name}' does not exist")
+
+        graph = self.db.graph(graph_name)
+
+        target_e_d = {}
+        for e_d in graph.edge_definitions():
+            if e_d["edge_collection"] == edge_collection_name:
+                target_e_d = e_d
+                break
+
+        if not target_e_d:
+            m = f"No edge definition found for '{edge_collection_name}' in graph '{graph_name}'. Cannot migrate edges to attributes."  # noqa: E501
+            raise ValueError(m)
+
+        if not attribute_name:
+            attribute_name = f"_{edge_collection_name}"
+
+        count = 0
+        for v_col in target_e_d["from_vertex_collections"]:
+            query = f"""
+                FOR doc IN @@v_col
+                    LET labels = (
+                        FOR v IN 1 OUTBOUND doc @@e_col
+                            RETURN v._label
+                    )
+
+                    UPDATE doc WITH {{{attribute_name}: labels}} IN @@v_col
+            """
+
+            self.db.aql.execute(
+                query, bind_vars={"@v_col": v_col, "@e_col": edge_collection_name}
+            )
+
+            count += self.db.collection(v_col).count()
+
+        m = f"Propagated {count} type statements as attributes"
+        logger.info(m)
+
+        return count
 
     #######################################
     # Public: RDF -> ArangoDB (RPT & PGT) #
@@ -2195,12 +2278,17 @@ class ArangoRDF(AbstractArangoRDF):
         else:
             t_col = self.__adb_col_statements.value(t, self.adb_col_uri)
 
-            if t_col is None and self.__iri_collection is not None:
-                doc = self.__iri_collection.get(t_key)
+            if self.__resource_collection is not None:
+                if str(t_col) not in {"Class", "Property"}:
+                    t_col = self.__resource_collection.name
 
-                if doc:
-                    t_col = str(doc["collection"])
-                    self.__add_adb_col_statement(t, t_col)  # for next iteration
+            elif self.__uri_map_collection is not None:
+                if t_col is None:
+                    doc = self.__uri_map_collection.get(t_key)
+
+                    if doc:
+                        t_col = str(doc["collection"])
+                        self.__add_adb_col_statement(t, t_col)  # for next iteration
 
             if t_col is None:
                 logger.debug(f"Found unknown resource: {t} ({t_key})")
@@ -2308,6 +2396,17 @@ class ArangoRDF(AbstractArangoRDF):
                 "_rdftype": "URIRef",
             }
 
+            if (
+                self.__uri_map_collection is not None
+                and t_col != self.__UNKNOWN_RESOURCE
+            ):
+                uri_col = self.__uri_map_collection.name
+                self.__adb_docs[uri_col][t_key] = {
+                    "_key": t_key,
+                    "collection": t_col,
+                    "_uri": str(t),
+                }
+
         elif type(t) is BNode:
             self.__adb_docs[t_col][t_key] = {
                 "_key": t_key,
@@ -2322,14 +2421,6 @@ class ArangoRDF(AbstractArangoRDF):
 
         else:
             raise ValueError(f"Invalid type for RDF Term: {t}")  # pragma: no cover
-
-        if self.__iri_collection is not None and t_col != self.__UNKNOWN_RESOURCE:
-            iri_col = self.__iri_collection.name
-            self.__adb_docs[iri_col][t_key] = {
-                "_key": t_key,
-                "collection": t_col,
-                "_uri": str(t),
-            }
 
     def __pgt_process_rdf_literal(
         self,
@@ -2735,21 +2826,25 @@ class ArangoRDF(AbstractArangoRDF):
         :rtype: arango.graph.Graph
         """
         edge_definitions: List[Dict[str, Union[str, List[str]]]] = []
-
         all_v_cols: Set[str] = set()
         non_orphan_v_cols: Set[str] = set()
 
-        for col in self.__adb_col_statements.objects(
-            subject=None, predicate=self.adb_col_uri, unique=True
-        ):
-            all_v_cols.add(str(col))
+        if self.__resource_collection is not None:
+            all_v_cols.add(self.__resource_collection.name)
+            all_v_cols.add("Class")
+            all_v_cols.add("Property")
+        else:
+            for col in self.__adb_col_statements.objects(
+                subject=None, predicate=self.adb_col_uri, unique=True
+            ):
+                all_v_cols.add(str(col))
 
-        # TODO: Revisit the following
-        # This discard prevents these collections
-        # from appearing as empty collections in the graph
-        # (they don't actually hold any documents)
-        all_v_cols.discard("Statement")
-        all_v_cols.discard("List")
+            # TODO: Revisit the following
+            # This discard prevents these collections
+            # from appearing as empty collections in the graph
+            # (they don't actually hold any documents)
+            all_v_cols.discard("Statement")
+            all_v_cols.discard("List")
 
         for e_col, v_cols in self.__e_col_map.items():
             edge_definitions.append(
@@ -2764,10 +2859,12 @@ class ArangoRDF(AbstractArangoRDF):
                 c for c in v_cols["from"] | v_cols["to"] if c not in self.__e_col_map
             }
 
-        orphan_v_cols = list(all_v_cols ^ non_orphan_v_cols ^ {self.__UNKNOWN_RESOURCE})
+        orphan_v_cols = all_v_cols ^ non_orphan_v_cols
+        if self.__resource_collection is None:
+            orphan_v_cols = orphan_v_cols ^ {self.__UNKNOWN_RESOURCE}
 
         if not self.db.has_graph(name):
-            return self.db.create_graph(name, edge_definitions, orphan_v_cols)
+            return self.db.create_graph(name, edge_definitions, list(orphan_v_cols))
 
         old_edge_definitions = {
             edge_def["edge_collection"]: edge_def

--- a/arango_rdf/main.py
+++ b/arango_rdf/main.py
@@ -1296,9 +1296,13 @@ class ArangoRDF(AbstractArangoRDF):
         if not attribute_name:
             attribute_name = f"_{edge_collection_name}"
 
+        with_cols = set(target_e_d["to_vertex_collections"])
+        with_cols_str = "WITH " + ", ".join(with_cols)
+
         count = 0
         for v_col in target_e_d["from_vertex_collections"]:
             query = f"""
+                {with_cols_str}
                 FOR doc IN @@v_col
                     LET labels = (
                         FOR v IN 1 {edge_direction} doc @@e_col

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5495,10 +5495,8 @@ def test_pgt_resource_collection_name_and_set_types_attribute() -> None:
             graph_name="Test", edge_collection_name="INVALID"
         )
 
-    assert (
-        "No edge definition found for 'INVALID' in graph 'Test'. Cannot migrate edges to attributes."
-        in str(e.value)
-    )
+    m = "No edge definition found for 'INVALID' in graph 'Test'. Cannot migrate edges to attributes."  # noqa: E501
+    assert m in str(e.value)
 
     with pytest.raises(ValueError) as e:
         adbrdf.migrate_edges_to_attributes(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5039,9 +5039,9 @@ def test_namespace_collection(graph_name: str, rdf_graph: RDFGraph) -> None:
     db.delete_collection("namespaces")
 
 
-def test_pgt_iri_collection_and_migrate_unknown_resources() -> None:
+def test_pgt_uri_collection_and_migrate_unknown_resources() -> None:
     db.delete_graph("Test", drop_collections=True, ignore_missing=True)
-    db.delete_collection("IRI_COLLECTION", ignore_missing=True)
+    db.delete_collection("URI_COLLECTION", ignore_missing=True)
 
     g1 = RDFGraph()
     g1.parse(
@@ -5067,23 +5067,23 @@ def test_pgt_iri_collection_and_migrate_unknown_resources() -> None:
         format="turtle",
     )
 
-    adbrdf.rdf_to_arangodb_by_pgt("Test", g1, iri_collection_name="IRI_COLLECTION")
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g1, uri_map_collection_name="URI_COLLECTION")
 
-    assert db.collection("IRI_COLLECTION").count() == 5
-    assert db.collection("IRI_COLLECTION").has(adbrdf.hash("http://example.com/Alice"))
-    assert db.collection("IRI_COLLECTION").has(
+    assert db.collection("URI_COLLECTION").count() == 5
+    assert db.collection("URI_COLLECTION").has(adbrdf.hash("http://example.com/Alice"))
+    assert db.collection("URI_COLLECTION").has(
         adbrdf.hash("http://example.com/GreatBook")
     )
-    assert db.collection("IRI_COLLECTION").has(adbrdf.hash("http://example.com/Person"))
-    assert db.collection("IRI_COLLECTION").has(adbrdf.hash("http://example.com/Book"))
-    assert db.collection("IRI_COLLECTION").has(
+    assert db.collection("URI_COLLECTION").has(adbrdf.hash("http://example.com/Person"))
+    assert db.collection("URI_COLLECTION").has(adbrdf.hash("http://example.com/Book"))
+    assert db.collection("URI_COLLECTION").has(
         adbrdf.hash("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
     )
 
     # No IRI Collection is specified, so Unknown Resources must be manually migrated
     adbrdf.rdf_to_arangodb_by_pgt("Test", g2)
 
-    assert db.collection("IRI_COLLECTION").count() == 5
+    assert db.collection("URI_COLLECTION").count() == 5
     assert db.collection("Test_UnknownResource").count() == 2
     assert db.collection("Test_UnknownResource").has(
         adbrdf.hash("http://example.com/Alice")
@@ -5103,7 +5103,7 @@ def test_pgt_iri_collection_and_migrate_unknown_resources() -> None:
     assert "age" not in alice_2
 
     # Migrate Unknown Resources to IRI Collection
-    adbrdf.migrate_unknown_resources("Test", "IRI_COLLECTION")
+    adbrdf.migrate_unknown_resources("Test", "URI_COLLECTION")
 
     assert db.collection("Test_UnknownResource").count() == 0
     edge = db.collection("wrote").random()
@@ -5117,12 +5117,12 @@ def test_pgt_iri_collection_and_migrate_unknown_resources() -> None:
     assert book["title"] == "The Great Novel"
 
     db.delete_graph("Test", drop_collections=True)
-    db.delete_collection("IRI_COLLECTION")
+    db.delete_collection("URI_COLLECTION")
 
 
-def test_pgt_iri_collection_back_to_back() -> None:
+def test_pgt_uri_collection_back_to_back() -> None:
     db.delete_graph("Test", drop_collections=True, ignore_missing=True)
-    db.delete_collection("IRI_COLLECTION", ignore_missing=True)
+    db.delete_collection("URI_COLLECTION", ignore_missing=True)
 
     g1 = RDFGraph()
     g1.parse(
@@ -5148,8 +5148,8 @@ def test_pgt_iri_collection_back_to_back() -> None:
         format="turtle",
     )
 
-    adbrdf.rdf_to_arangodb_by_pgt("Test", g1, iri_collection_name="IRI_COLLECTION")
-    adbrdf.rdf_to_arangodb_by_pgt("Test", g2, iri_collection_name="IRI_COLLECTION")
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g1, uri_map_collection_name="URI_COLLECTION")
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g2, uri_map_collection_name="URI_COLLECTION")
 
     assert db.collection("Test_UnknownResource").count() == 0
     edge = db.collection("wrote").random()
@@ -5163,12 +5163,12 @@ def test_pgt_iri_collection_back_to_back() -> None:
     assert book["title"] == "The Great Novel"
 
     db.delete_graph("Test", drop_collections=True)
-    db.delete_collection("IRI_COLLECTION")
+    db.delete_collection("URI_COLLECTION")
 
 
-def test_pgt_iri_collection_back_to_back_with_unknown_resources() -> None:
+def test_pgt_uri_collection_back_to_back_with_unknown_resources() -> None:
     db.delete_graph("Test", drop_collections=True, ignore_missing=True)
-    db.delete_collection("IRI_COLLECTION", ignore_missing=True)
+    db.delete_collection("URI_COLLECTION", ignore_missing=True)
 
     g1 = RDFGraph()
     g1.parse(
@@ -5211,10 +5211,10 @@ def test_pgt_iri_collection_back_to_back_with_unknown_resources() -> None:
         format="turtle",
     )
 
-    adbrdf.rdf_to_arangodb_by_pgt("Test", g1, iri_collection_name="IRI_COLLECTION")
-    adbrdf.rdf_to_arangodb_by_pgt("Test", g2, iri_collection_name="IRI_COLLECTION")
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g1, uri_map_collection_name="URI_COLLECTION")
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g2, uri_map_collection_name="URI_COLLECTION")
 
-    assert db.collection("IRI_COLLECTION").count() == 20
+    assert db.collection("URI_COLLECTION").count() == 20
     assert db.collection("Test_UnknownResource").count() == 4
     assert db.collection("Test_UnknownResource").has(
         adbrdf.hash("http://example.com/A")
@@ -5239,12 +5239,12 @@ def test_pgt_iri_collection_back_to_back_with_unknown_resources() -> None:
 
     assert "UnknownResource/" in db.collection("reads").random()["_to"]
 
-    ur_count, edge_count = adbrdf.migrate_unknown_resources("Test", "IRI_COLLECTION")
+    ur_count, edge_count = adbrdf.migrate_unknown_resources("Test", "URI_COLLECTION")
     assert ur_count == 4
     assert edge_count == 7  # 1 edit for each _from/_to if UnknownResource is migrated
 
     assert db.collection("Test_UnknownResource").count() == 0
-    assert db.collection("IRI_COLLECTION").count() == 20
+    assert db.collection("URI_COLLECTION").count() == 20
 
     assert db.collection("Book").random()["title"] == "The Great Novel"
 
@@ -5259,12 +5259,12 @@ def test_pgt_iri_collection_back_to_back_with_unknown_resources() -> None:
     assert "Book/" in db.collection("reads").random()["_to"]
 
     db.delete_graph("Test", drop_collections=True)
-    db.delete_collection("IRI_COLLECTION")
+    db.delete_collection("URI_COLLECTION")
 
 
-def test_pgt_iri_collection_back_to_back_with_type_statements() -> None:
+def test_pgt_uri_collection_back_to_back_with_type_statements() -> None:
     db.delete_graph("Test", drop_collections=True, ignore_missing=True)
-    db.delete_collection("IRI_COLLECTION", ignore_missing=True)
+    db.delete_collection("URI_COLLECTION", ignore_missing=True)
 
     g1 = RDFGraph()
     g1.parse(
@@ -5286,11 +5286,11 @@ def test_pgt_iri_collection_back_to_back_with_type_statements() -> None:
         format="turtle",
     )
 
-    adbrdf.rdf_to_arangodb_by_pgt("Test", g1, iri_collection_name="IRI_COLLECTION")
-    adbrdf.rdf_to_arangodb_by_pgt("Test", g2, iri_collection_name="IRI_COLLECTION")
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g1, uri_map_collection_name="URI_COLLECTION")
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g2, uri_map_collection_name="URI_COLLECTION")
 
     assert (
-        db.document(f"IRI_COLLECTION/{adbrdf.hash('http://example.com/Alice')}")[
+        db.document(f"URI_COLLECTION/{adbrdf.hash('http://example.com/Alice')}")[
             "collection"
         ]
         == "Person"
@@ -5300,7 +5300,7 @@ def test_pgt_iri_collection_back_to_back_with_type_statements() -> None:
     assert not db.has_collection("Human")
 
     db.delete_graph("Test", drop_collections=True)
-    db.delete_collection("IRI_COLLECTION")
+    db.delete_collection("URI_COLLECTION")
 
 
 def test_pgt_import_exception_from_schema_violation() -> None:
@@ -5350,5 +5350,113 @@ def test_pgt_import_exception_from_schema_violation() -> None:
     )
 
     adbrdf.rdf_to_arangodb_by_pgt("Test", g)
+
+    db.delete_graph("Test", drop_collections=True)
+
+
+def test_pgt_resource_collection_name_and_set_types_attribute() -> None:
+    db.delete_graph("Test", drop_collections=True, ignore_missing=True)
+
+    g = RDFGraph()
+    g.parse(
+        data="""
+        @prefix ex: <http://example.com/> .
+
+        ex:Alice a ex:Person .
+        ex:Alice a ex:Human .
+        ex:Alice ex:name "Alice" .
+        ex:Alice ex:age 25 .
+
+        ex:Bob a ex:Person .
+        ex:Bob a ex:Human .
+        ex:Bob ex:name "Bob" .
+        ex:Bob ex:age 30 .
+
+        ex:Alice ex:friend ex:Bob .
+
+        ex:ACME a ex:Organization .
+        ex:ACME a ex:Company .
+        """,
+        format="turtle",
+    )
+
+    with pytest.raises(ValueError) as e:
+        adbrdf.rdf_to_arangodb_by_pgt(
+            "Test",
+            g,
+            resource_collection_name="Node",
+            uri_map_collection_name="URI_COLLECTION",
+        )
+
+    m = "Cannot specify both **uri_map_collection_name** and **resource_collection_name**."  # noqa: E501
+    assert m in str(e.value)
+
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g, resource_collection_name="Node")
+
+    assert not db.has_collection("Person")
+    assert not db.has_collection("Human")
+    assert not db.has_collection("Test_UnknownResource")
+    assert db.has_collection("Node")
+    assert db.collection("Node").count() == 3
+    assert db.collection("Node").has(adbrdf.hash("http://example.com/Alice"))
+    assert db.collection("Node").has(adbrdf.hash("http://example.com/Bob"))
+    assert db.collection("Node").has(adbrdf.hash("http://example.com/ACME"))
+
+    assert db.collection("Class").count() == 4
+    assert db.collection("Property").count() == 4
+
+    assert db.collection("friend").count() == 1
+    edge = db.collection("friend").random()
+    assert "Node/" in edge["_from"]
+    assert "Node/" in edge["_to"]
+
+    for edge in db.collection("type"):
+        assert "Node/" in edge["_from"]
+        assert "Class/" in edge["_to"]
+
+    for node in db.collection("Node"):
+        assert "_type" not in node
+
+    count = adbrdf.migrate_edges_to_attributes("Test", "type")
+
+    node_col = db.collection("Node")
+    assert set(node_col.get(adbrdf.hash("http://example.com/Alice"))["_type"]) == {
+        "Person",
+        "Human",
+    }
+    assert set(node_col.get(adbrdf.hash("http://example.com/Bob"))["_type"]) == {
+        "Person",
+        "Human",
+    }
+    assert set(node_col.get(adbrdf.hash("http://example.com/ACME"))["_type"]) == {
+        "Organization",
+        "Company",
+    }
+    assert count == 3
+
+    db.delete_graph("Test", drop_collections=True)
+
+    adbrdf.rdf_to_arangodb_by_pgt("Test", g)
+
+    assert not db.has_collection("Node")
+    assert db.has_collection("Human")
+    assert not db.has_collection("Person")
+    assert db.has_collection("Company")
+    assert not db.has_collection("Organization")
+
+    for v in db.collection("Human"):
+        assert "_type" not in v
+
+    for v in db.collection("Company"):
+        assert "_type" not in v
+
+    count = adbrdf.migrate_edges_to_attributes("Test", "type", "foo")
+    assert count == 3
+
+    for v in db.collection("Human"):
+        assert set(v["foo"]) == {"Person", "Human"}
+
+    for v in db.collection("Company"):
+        assert set(v["foo"]) == {"Organization", "Company"}
 
     db.delete_graph("Test", drop_collections=True)


### PR DESCRIPTION
Test with:

```
pip install git+https://github.com/ArangoDB-Community/ArangoRDF@ressource-collection-name-and-migrate-edge-as-attributes
```


3 Changes:

- Introduces `resource_collection_name` to the `rdf_to_arangodb_by_pgt()` method which proposes to replace some of the ArangoDB Collection Mapping Process with a simpler approach: **store all RDF Resources in one ArangoDB Collection**. This can be beneficial for those wanting to benefit from having a simpler ArangoDB Graph to manage.

- Introduces `migrate_edges_to_attributes()` as a general PGT method. Similar to `migrate_unknown_resources()`, this function can be called after invoking `rdf_to_arangodb_by_pgt()` to transform Edges into Document Properties. For example, this method can be used to **convert all `type` edges into a `_type` property on each document`.

- Refactor `iri_collection_name` to `uri_map_collection_name`: Due to risk of confusion between `iri_collection_name` and `resource_collection_name`, this parameter has been renamed to `uri_map_collection_name`. Functionality remains the same.

### Example usage

```python
from rdflib import Graph as RDFGraph

g = RDFGraph()
g.parse(
        data="""
        @prefix ex: <http://example.com/> .

        ex:Alice a ex:Person .
        ex:Alice a ex:Human .
        ex:Alice ex:name "Alice" .
        ex:Alice ex:age 25 .

        ex:Bob a ex:Person .
        ex:Bob a ex:Human .
        ex:Bob ex:name "Bob" .
        ex:Bob ex:age 30 .

        ex:Alice ex:friend ex:Bob .

        ex:ACME a ex:Organization .
        ex:ACME a ex:Company .
        """,
        format="turtle",
)

adbrdf.rdf_to_arangodb_by_pgt("MyGraph", g, resource_collection_name="Node")
# Result: Alice, Bob, and ACME will be placed under the "Node" Collection in ArangoDB


count = adbrdf.migrate_edges_to_attributes(
    graph_name="MyGraph", edge_collection_name="type"
)

assert count == 3

# Result: Alice, Bob, and ACME will now have a _type attribute on their documents
# Alice._type == ["Person", "Human"]
# Bob._type == ["Person", "Human"]
# ACME._type == ["Organization", "Company"]

count = adbrdf.migrate_edges_to_attributes(
    graph_name="MyGraph", edge_collection_name="friend"
)

assert count == 2

# Result: Alice and Bob now have a _friend attribute
# Alice._friend == ["Bob"]
# Bob._friend == [] ### <----- NOTE: Bob is not the Source of any `friend` edge, therefore the attribute is empty.
# To fix this, set `edge_direction` to ANY:

count = adbrdf.migrate_edges_to_attributes(
    graph_name="MyGraph", edge_collection_name="friend", edge_direction="ANY"
)

assert count == 2

# Alice._friend == ["Bob"]
# Bob._friend == ["Alice"]
```